### PR TITLE
Avoid to use the bottle attribute and better management of the URLs and version

### DIFF
--- a/Formula/kubecolor.rb
+++ b/Formula/kubecolor.rb
@@ -6,22 +6,21 @@ class Kubecolor < Formula
   desc "Colorize your kubectl output"
   homepage "https://github.com/dty1er/kubecolor"
   version "0.0.20"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://github.com/dty1er/kubecolor/releases/download/v0.0.20/kubecolor_0.0.20_Darwin_x86_64.tar.gz"
+    url "https://github.com/dty1er/kubecolor/releases/download/v#{version}/kubecolor_#{version}_Darwin_x86_64.tar.gz"
     sha256 "798d055fb6b7c6757046814b41f9d1abeea17dae7b8ab94ed9f6f91684b0fc83"
   end
   if OS.mac? && Hardware::CPU.arm?
-    url "https://github.com/dty1er/kubecolor/releases/download/v0.0.20/kubecolor_0.0.20_Darwin_arm64.tar.gz"
+    url "https://github.com/dty1er/kubecolor/releases/download/v#{version}/kubecolor_#{version}_Darwin_arm64.tar.gz"
     sha256 "73860e70a63aea26f45d40aea7a1f5bf65456391ac295d1894ee4b052777a66e"
   end
   if OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/dty1er/kubecolor/releases/download/v0.0.20/kubecolor_0.0.20_Linux_x86_64.tar.gz"
+    url "https://github.com/dty1er/kubecolor/releases/download/v#{version}/kubecolor_#{version}_Linux_x86_64.tar.gz"
     sha256 "e53ed0ea2c9846004907950f47c59f749077a0b44c1da84ca2e1139070c3d3c3"
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://github.com/dty1er/kubecolor/releases/download/v0.0.20/kubecolor_0.0.20_Linux_arm64.tar.gz"
+    url "https://github.com/dty1er/kubecolor/releases/download/v#{version}/kubecolor_#{version}_Linux_arm64.tar.gz"
     sha256 "7c0ef96168bfe33ef07d3e77f9e2b415365772f8c2643e434a4c5107f4696e65"
   end
 


### PR DESCRIPTION
This small change will help to stop seeing the annoying warnings on each `brew` command, as an additional change, I thought it could be a nice idea to do not to repeat the version number across the URLs, it's less error-prone